### PR TITLE
Add perl package installation to RedHat tasks

### DIFF
--- a/tasks/redhat-fam.yml
+++ b/tasks/redhat-fam.yml
@@ -5,6 +5,7 @@
       {{ ansible_pkg_mgr }} name={{ item }} state=present update_cache=yes
     with_items:
       - wget
+      - perl
 
   - name: Subscribe to official Dell yum repos
     shell: wget -q -O - http://linux.dell.com/repo/hardware/dsu/bootstrap.cgi | bash


### PR DESCRIPTION
CentOS 7 doesn't have perl installed in the clean install. One of the Dell tools needs it, however it's not installed as a dependency, so I put it as a prerequisite along with wget.